### PR TITLE
Doc type

### DIFF
--- a/application/controllers/DocumentsController.php
+++ b/application/controllers/DocumentsController.php
@@ -11,8 +11,8 @@ class DocumentsController extends Controller
 {
     public function indexAction()
     {
-        $index = $this->params->getRequired('index');
-        $type = $this->params->getRequired('type');
+	$index = $this->params->getRequired('index');
+	$type = "_doc";
         $id = $this->params->getRequired('id');
 
         $instance = (new Instances())

--- a/application/views/scripts/events/index.phtml
+++ b/application/views/scripts/events/index.phtml
@@ -22,7 +22,7 @@
         </thead>
         <tbody>
         <?php foreach ($events as $event): ?>
-            <tr href="<?= $documentsUri->with(array('index' => $event['_index'], 'type' => $event['_type'], 'id' => $event['_id'])) ?>">
+            <tr href="<?= $documentsUri->with(array('index' => $event['_index'], 'id' => $event['_id'])) ?>">
             <?php foreach ($fields as $getter):
                 $column = $getter($event['_source']);
                 $ellipsis = $this->ellipsis($column, 100);

--- a/public/css/module.less
+++ b/public/css/module.less
@@ -1,4 +1,4 @@
-/* Icinga Web 2 Elasticsearch Module (c) 2017 Icinga Development Team | GPLv2+ */
+/* Icinga Web 2 Elasticsearch Module (c) 2021 Icinga GmbH | GPLv2+ */
 
 .auto-refresh-control {
   display: inline-block;
@@ -48,8 +48,8 @@
 }
 
 .grid-item-header {
-  background: #ef4f98;
-  color: white;
+  background: var(--icinga-secondary, @icinga-secondary);
+  color: var(--text-color, @text-color);
   display: flex;
   flex-direction: column;
   height: 3em;
@@ -61,8 +61,8 @@
 }
 
 .missing-configuration-error {
-  background-color: @color-unknown;
-  color: #fff;
+  background-color: var(--color-unknown, @color-unknown);
+  color: var(--text-color, @text-color);
   display: inline-block;
   padding: 1em;
 }
@@ -92,7 +92,7 @@
   }
 
   > tbody tr:nth-child(odd) {
-    background-color: @gray-lightest;
+    background-color: var(--gray-lightest, @gray-lightest);
   }
 
   > tbody {
@@ -106,12 +106,12 @@
     }
 
     tr[href].active {
-      background-color: @tr-active-color;
-      border-left-color: @icinga-blue;
+      background-color: var(--tr-active-color, @tr-active-color);
+      border-left-color: var(--icinga-blue, @icinga-blue);
     }
 
     tr[href]:hover {
-      background-color: @tr-hover-color;
+      background-color: var(--tr-hover-color, @tr-hover-color);
       cursor: pointer;
     }
   }


### PR DESCRIPTION
fixed _doc type:

Errors:
- Undefined array key "_type"
- Required parameter 'type' missing

use type "_doc" as default in request uri.
Field "type" is no longer present in response.

Both related to OpenSearch 2.4.0

_type (Deprecated) The default document type for documents that don’t specify a type.
